### PR TITLE
Replace erlang:now() with erlang:timestamp()

### DIFF
--- a/src/orca.erl
+++ b/src/orca.erl
@@ -107,7 +107,7 @@ result( {ok, {err_packet, Props}} ) ->
 	{ok, OrcaError}.
 
 now_ms() ->
-	{MegS, S, MuS} = erlang:now(),
+	{MegS, S, MuS} = erlang:timestamp(),
 	(((MegS * 1000000) + S) * 1000) + (MuS div 1000).
 
 await_ready_impl( ConnMgr, PingInterval, Deadline ) ->

--- a/src/orca_conn_mgr.erl
+++ b/src/orca_conn_mgr.erl
@@ -380,7 +380,7 @@ restart_frequency_exceeded( Idx, #conn_pool{ min_restart_interval = MinRestartIn
 
 
 now_ms() ->
-	{MegS, S, MuS} = erlang:now(),
+	{MegS, S, MuS} = erlang:timestamp(),
 	(((MegS * 1000000) + S) * 1000) + (MuS div 1000).
 
 conn_pool_worker_start( Idx, ConnPool0 = #conn_pool{ workers = Workers0, sup = Sup } ) ->


### PR DESCRIPTION
Makes `make compile` happy (tested with Erlang 18.0.3 on OS X 10.10.5).
For more details refer to ERTS User's Guide: http://www.erlang.org/doc/apps/erts/time_correction.html
